### PR TITLE
Fix import path for ConnectedAccountProvider

### DIFF
--- a/packages/twenty-front/src/modules/activities/emails/hooks/useEmailThread.ts
+++ b/packages/twenty-front/src/modules/activities/emails/hooks/useEmailThread.ts
@@ -4,7 +4,7 @@ import { useOpenEmailThreadRightDrawer } from '@/activities/emails/right-drawer/
 import { viewableRecordIdState } from '@/object-record/record-right-drawer/states/viewableRecordIdState';
 import { useRightDrawer } from '@/ui/layout/right-drawer/hooks/useRightDrawer';
 import { isRightDrawerOpenState } from '@/ui/layout/right-drawer/states/isRightDrawerOpenState';
-import { ConnectedAccountProvider } from '@/modules/accounts/types/MessageChannel';
+import { ConnectedAccountProvider } from 'twenty-shared';
 import { fetchIMAPEmailThread } from '@/modules/activities/emails/utils/fetchIMAPEmailThread';
 
 export const useEmailThread = () => {


### PR DESCRIPTION
Update import path for `ConnectedAccountProvider` in `useEmailThread.ts`.

* Change import path for `ConnectedAccountProvider` from `@/modules/accounts/types/MessageChannel` to `twenty-shared`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/santibm/twenty/pull/2?shareId=62ce9353-b33c-4555-852b-031e3e00dcc0).